### PR TITLE
A problem about character conversion of psd.js

### DIFF
--- a/lib/psd/file.coffee
+++ b/lib/psd/file.coffee
@@ -1,4 +1,5 @@
 {jspack} = require 'jspack'
+iconv = require 'iconv-lite'
 Util = require './util.coffee'
 
 module.exports = class File
@@ -41,10 +42,8 @@ module.exports = class File
   readString: (length) -> String.fromCharCode.apply(null, @read(length)).replace /\u0000/g, ""
   readUnicodeString: (length = null) ->
     length or= @readInt()
-    @read(length * 2)
-      .map((c) -> Util.getUnicodeCharacter(c))
-      .join('')
-      .replace(/\u0000/g, '')
+    data = new Buffer(@read(length * 2))
+    iconv.decode(data, 'utf-16be')
 
   readByte: -> @read(1)[0]
   readBoolean: -> @readByte() isnt 0

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "coffeescript-module": "~ 0.2.1",
     "pngjs": "~ 0.4.0",
     "rsvp": "~ 3.0.6",
-    "lodash": "~ 2.4"
+    "lodash": "~ 2.4",
+    "iconv-lite": "~ 0.4.4"
   },
   "scripts": {
     "test": "mocha test"


### PR DESCRIPTION
Hi meltingice, when I use psd.js , I find it doesn't deal with text layer, so I write a module according to the file in the layer_info folder, here is the file link: https://github.com/imgqb/psd.js/blob/textLayer/lib/psd/layer_info/text_elements.coffee

And I was surprised to find I can get the infomation in the text layer using the code below

```
psd.tree().children()[0].get('textElements').textData;
```

And the text value is stores in the 'Txt ' field. It's really exciting.

But,  the problem attendant. I'm from China, so there are some Chinese characters in the text layer.And I read the descriptor.coffee and file.coffee, find there are using 'String.fromCharCode()' to convert characters. So, I only see garbled text in CMD.

Although I try to use ‘charCodeAt()’ to get an array, then use 'new Buffer(array)' to create a buffer in node.js, finally try to decode the buffer. However , it's still failed.

My programming skills and knowledge is not good.So, could you give some advices. Thanks :)
