### PR TITLE
add parse layer link section

### DIFF
--- a/lib/psd/resource_section.coffee
+++ b/lib/psd/resource_section.coffee
@@ -3,6 +3,7 @@ _ = require 'lodash'
 module.exports = class ResourceSection
   RESOURCES = [
     require('./resources/layer_comps.coffee')
+    require('./resources/layer_links.coffee')
   ]
 
   @factory: (resource) ->

--- a/lib/psd/resources/layer_links.coffee
+++ b/lib/psd/resources/layer_links.coffee
@@ -1,0 +1,17 @@
+module.exports = class LinkLayers
+
+  id: 1026
+  name: 'LinkLayers'
+
+  constructor: (@resource) ->
+    @file = @resource.file
+    @linkArray = []
+
+  parse: ->
+    end = @file.tell() + @resource.length
+
+    while end > @file.tell()
+      @linkArray.push(@file.readShort())
+    
+    #in the same order as layers
+    @linkArray.reverse();


### PR DESCRIPTION
add layer link section; layer link represented by array in psd;
for example: 
1.
![](http://ww3.sinaimg.cn/large/6d4195cfgw1emanc9f0p0j206n03nwef.jpg)

layer3 and layer1 are linked;

then the array is [1, 1, 0]

2 if there are more layer links

![](http://ww4.sinaimg.cn/large/6d4195cfgw1emangjopmgj206l05p74b.jpg)

layer3 and layer1 are linked; layer4 and layer2 are linked;

then the array is [1, 2, 0, 1, 2]

3 if there are some group layer ,but not linked;

![](http://ww1.sinaimg.cn/large/6d4195cfgw1emank0x7drj206s06gq31.jpg)

layer3 and layer1 are linked; layer4 and layer2 are linked;

then the array is [ 0, 1, 2, 0, 0, 1, 2 ];

yes, we find group layer create 2 element in the array; here, I call them groupStart and groupEnd;

4 if there are some group layer, and they are linked;

![](http://ww4.sinaimg.cn/large/6d4195cfgw1emano1akwoj206h06aaa5.jpg)

layer3 and layer1 are linked; layer4 and layer2 are linked;  folder1 and layer5 are linked;

then the array is [ 3, 1, 2, 0, 3, 1, 2 ]; we find the groupStart is not zero, and the groupEnd also is zero;

Through the above,find:
 same linked layers , they have same number, not zero;
group layer has two numbers, and the groupEnd always zero;

OK, through some processing we could get which layer are linked mutually
