### PR TITLE
Added #toBase64 and #fromDroppedFile:

### DIFF
--- a/shims/init.coffee
+++ b/shims/init.coffee
@@ -28,3 +28,15 @@ module.exports =
 
         reader.onerror = reject
         reader.readAsArrayBuffer(file)
+
+    @fromDroppedFile = (file) ->
+      new RSVP.Promise (resolve, reject) ->
+        reader = new FileReader()
+        reader.onload = (e) ->
+          psd = new PSD(new Uint8Array(e.target.result))
+          psd.parse()
+
+          resolve(psd)
+
+        reader.onerror = reject
+        reader.readAsArrayBuffer(file)

--- a/shims/png.coffee
+++ b/shims/png.coffee
@@ -1,27 +1,31 @@
 RSVP = require 'rsvp'
 
 module.exports = 
+  toBase64: ->
+    # Draw the pixels to the canvas
+    canvas = document.createElement('canvas')
+    canvas.width = @width()
+    canvas.height = @height()
+    context = canvas.getContext('2d')
+
+    imageData = context.getImageData(0, 0, @width(), @height())
+    pixelData = imageData.data
+
+    pixelData[i] = pixel for pixel, i in @pixelData
+
+    context.putImageData(imageData, 0, 0)
+
+    canvas.toDataURL 'image/png'
+
   toPng: ->
     new RSVP.Promise (resolve, reject) =>
-      # Draw the pixels to the canvas
-      canvas = document.createElement('canvas')
-      canvas.width = @width()
-      canvas.height = @height()
-      context = canvas.getContext('2d')
-
-      imageData = context.getImageData(0, 0, @width(), @height())
-      pixelData = imageData.data
-
-      pixelData[i] = pixel for pixel, i in @pixelData
-
-      context.putImageData(imageData, 0, 0)
-
+      dataUrl = @toBase64()
       # Create the image and set the source to the
       # canvas data URL.
       image = new Image()
       image.width = @width()
       image.height = @height()
-      image.src = canvas.toDataURL 'image/png'
+      image.src = dataUrl
 
       resolve(image)
 


### PR DESCRIPTION
I added this to fit with a use case I had in an application. Great library, by the way :)

I didn't include the compiled JS file, thought I should leave that to you @meltingice!

- .toBase64 is for situations where you want to control what happens to the URL. Maybe you want to upload it, rather than put it straight into an image - or maybe you want to use it as an image in a CSS background. At any rate, the code is exactly the same for toPng, but I put a lot of it into the toBase64 function
- .fromDroppedFile is very similar to fromEvent, only it assumes that you already have the file extracted from the drop event. This is useful e.g. with the Dropzone JS library, which exposes the file in an 'addedFile' event.