### PR TITLE
Fix: the MIME type being generated by the base64 shim was incorrect. Now it is correct.

### DIFF
--- a/shims/png.coffee
+++ b/shims/png.coffee
@@ -15,7 +15,7 @@ module.exports =
 
     context.putImageData(imageData, 0, 0)
 
-    canvas.toDataURL 'image/png'
+    canvas.toDataURL('image/png')
 
   toPng: ->
     dataUrl = @toBase64()


### PR DESCRIPTION
It was creating a base64 string with the PSD mime type, rather than PNG - I guess because of a syntax error. Sorry, I am not very good at coffeescript ;)