### PR TITLE
fix broken test

### DIFF
--- a/test/png_exporting.coffee
+++ b/test/png_exporting.coffee
@@ -25,6 +25,6 @@ describe "exporting from a PSD", ->
       fs.statSync(filePath).size
       .should
       .eql(fs.statSync(expectedPath).size)
-    .then -> done()
-    .catch done
+    .then -> done
+    .catch done()
 


### PR DESCRIPTION
The one test that did exist was broken.
This fixes that and allows reviewers and people building PR's to test the code before committing/merging it.

@meltingice I will add more later on if that is something you would like to see.