### PR TITLE
close #115 - add resolution info

### DIFF
--- a/lib/psd/nodes/root.coffee
+++ b/lib/psd/nodes/root.coffee
@@ -7,7 +7,7 @@ module.exports = class Root extends Node
   @layerForPsd: (psd) ->
     layer = {}
     layer[prop] = null for prop in Node.PROPERTIES
-    
+
     layer.top = 0
     layer.left = 0
     layer.right = psd.header.width
@@ -36,6 +36,7 @@ module.exports = class Root extends Node
       height: @height
       resources:
         layerComps: @psd.resources.resource('layerComps')?.export() or []
+        resolutionInfo: @psd.resources.resource('resolutionInfo')?.export() or []
         guides: []
         slices: []
 

--- a/lib/psd/resource_section.coffee
+++ b/lib/psd/resource_section.coffee
@@ -4,6 +4,7 @@ module.exports = class ResourceSection
   RESOURCES = [
     require('./resources/layer_comps.coffee')
     require('./resources/layer_links.coffee')
+    require('./resources/resolution_info.coffee')
   ]
 
   @factory: (resource) ->

--- a/lib/psd/resources/resolution_info.coffee
+++ b/lib/psd/resources/resolution_info.coffee
@@ -1,0 +1,26 @@
+module.exports = class ResolutionInfo
+  id: 1005
+  name: 'resolutionInfo'
+
+  constructor: (@resource) ->
+    @file = @resource.file
+
+  parse: ->
+    # 32-bit fixed-point number (16.16)
+    @h_res = @file.readUInt() / 65536
+    @h_res_unit = @file.readUShort()
+    @width_unit = @file.readUShort()
+
+    # 32-bit fixed-point number (16.16)
+    @v_res = @file.readUInt() / 65536
+    @v_res_unit = @file.readUShort()
+    @height_unit = @file.readUShort()
+
+    @resource.data = @
+
+  export: ->
+    data = {}
+    for key in ['h_res', 'h_res_unit', 'width_unit', 'v_res', 'v_res_unit', 'height_unit']
+      data[key] = @[key]
+
+    data


### PR DESCRIPTION
I've run into the same problem as #115 - I needed resolution (DPI) information. [Official PSD file format doc](https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/) says that ResolutionInfo structure is on 1005 (decimal). Even the original psd.rb repo is extracting this ResolutionInfo here: https://github.com/layervault/psd.rb/blob/31c7ddddfc96181847579833bf384532de3b29d9/lib/psd/resources/resolution_info.rb

So that's simply what this PR does - follows psd.rb example and extracts resolution information from PSD.