### PR TITLE
Using typed array instead of native JS array

### DIFF
--- a/lib/psd/channel_image.coffee
+++ b/lib/psd/channel_image.coffee
@@ -24,7 +24,6 @@ module.exports = class ChannelImage extends Image
     @channelsInfo = @layer.channelsInfo
     @hasMask = _.any @channelsInfo, (c) -> c.id < -1
     @opacity = @layer.opacity / 255.0
-    @maskData = []
 
   # Skip parsing this image by jumping to the end of the data.
   skip: ->

--- a/lib/psd/image.coffee
+++ b/lib/psd/image.coffee
@@ -33,11 +33,13 @@ module.exports = class Image extends Module
     @calculateLength()
 
     # The resulting array that stores the pixel data, formatted in RGBA format.
-    @pixelData = []
+    @pixelData = new Uint8Array(@length)
+    @maskData =  new Uint8Array(@maskLength * 4)
 
     # This temporarily holds the raw channel data after it's been parsed, but not
     # processed.
-    @channelData = []
+    @channelData = new Uint8Array(@length + @maskLength)
+
     @opacity = 1.0
     @hasMask = false
 
@@ -66,6 +68,11 @@ module.exports = class Image extends Module
 
     @channelLength = @length
     @length *= @channels()
+
+    if @layer and @layer.mask.size
+      @maskLength = @layer.mask.width * @layer.mask.height
+    else
+      @maskLength = 0
 
   # Parses the image and formats the image data.
   parse: ->

--- a/lib/psd/image_exports/png.coffee
+++ b/lib/psd/image_exports/png.coffee
@@ -14,3 +14,15 @@ module.exports =
         .pack()
         .pipe(fs.createWriteStream(output))
         .on 'finish', resolve
+        
+  maskToPng: ->
+    png = new PNG(filterType: 4, width: @layer.mask.width, height: @layer.mask.height)
+    png.data = @maskData
+    png
+
+  saveMaskAsPng: (output) ->
+    new RSVP.Promise (resolve, reject) =>
+      @maskToPng()
+        .pack()
+        .pipe(fs.createWriteStream(output))
+        .on 'finish', resolve

--- a/lib/psd/image_formats/raw.coffee
+++ b/lib/psd/image_formats/raw.coffee
@@ -1,3 +1,3 @@
 module.exports =
   parseRaw: ->
-    @channelData = @file.read(@length)
+    @channelData.set @file.read(@length)

--- a/lib/psd/image_formats/rle.coffee
+++ b/lib/psd/image_formats/rle.coffee
@@ -5,30 +5,34 @@ module.exports =
 
   parseByteCounts: ->
     @file.readShort() for i in [0...(@channels() * @height())]
-
+  
   parseChannelData: ->
     @chanPos = 0
     @lineIndex = 0
-
     for i in [0...@channels()]
       @decodeRLEChannel()
       @lineIndex += @height()
-
+          
   decodeRLEChannel: ->
     for j in [0...@height()]
       byteCount = @byteCounts[@lineIndex + j]
       finish = @file.tell() + byteCount
-
+      
       while @file.tell() < finish
         len = @file.read(1)[0]
-
+        
         if len < 128
           len += 1
-          @channelData.splice @chanPos, 0, @file.read(len)...
+          #@channelData.splice @chanPos, 0, @file.read(len)...
+          data = @file.read(len)          
+          @channelData.set data, @chanPos
           @chanPos += len
         else if len > 128
           len ^= 0xff
           len += 2
 
           val = @file.read(1)[0]
-          @channelData[@chanPos++] = val for i in [0...len]
+          #@channelData[@chanPos++] = val for i in [0...len]
+          @channelData.fill(val, @chanPos, @chanPos+len)
+          @chanPos += len
+          

--- a/lib/psd/image_modes/cmyk.coffee
+++ b/lib/psd/image_modes/cmyk.coffee
@@ -30,4 +30,7 @@ module.exports =
           when 3 then k = val
 
       [r, g, b] = Color.cmykToRgb(255 - c, 255 - m, 255 - y, 255 - k)
-      @pixelData.push r, g, b, a
+      @pixelData.set([r, g, b, a], i*4)
+
+    @readMaskData(cmykChannels)
+

--- a/lib/psd/image_modes/greyscale.coffee
+++ b/lib/psd/image_modes/greyscale.coffee
@@ -11,4 +11,4 @@ module.exports =
       else
         255
 
-      @pixelData.push grey, grey, grey, alpha
+      @pixelData.set([grey, grey, grey, alpha], i*4)

--- a/lib/psd/image_modes/rgb.coffee
+++ b/lib/psd/image_modes/rgb.coffee
@@ -25,5 +25,15 @@ module.exports =
           when 0 then  r = val
           when 1 then  g = val
           when 2 then  b = val
+      @pixelData.set([r, g, b, a], i*4)
 
-      @pixelData.push r, g, b, a
+    @readMaskData(rgbChannels)
+
+  readMaskData: (rgbChannels) ->
+      
+    if @hasMask
+      maskPixels = @layer.mask.width * @layer.mask.height
+      offset = @channelLength * rgbChannels.length
+      for i in [0...maskPixels]
+        val = @channelData[i + offset]
+        @maskData.set([0, 0, 0, val], i*4)

--- a/lib/psd/layer/blending_ranges.coffee
+++ b/lib/psd/layer/blending_ranges.coffee
@@ -4,6 +4,8 @@ module.exports =
   # the ranges in both greyscale and for each color channel.
   parseBlendingRanges: ->
     length = @file.readInt()
+    if length == 0
+      return
 
     @blendingRanges.grey =
       source:


### PR DESCRIPTION
Current implementation uses native JS arrays for store layers image data. But JS arrays is very inefficient for store large binary data. I replaced them with Uint8Array. It is supported by all modern browsers as well as by NodeJS. It provides significant performance gain.
I used following psd file for testing https://drive.google.com/open?id=1LgGiHPgbr9Vrc7j0DCvXDSlFBBk5AmB5
Original version in my PC is trying to allocate about 1.5 GB of RAM and then it die with "JavaScript heap out of memory" error. See also the issue https://github.com/meltingice/psd.js/issues/135

My version uses less than 400 MB of RAM and it loads file successfully.

I have to apologize but this PR also contains code for my previous PR https://github.com/meltingice/psd.js/pull/117 that isn't merged yet. But in my project I need both ability to work with mask data and working with large PSD files (100 MB and more) so I cannot easlty separate them