### PR TITLE
fix to read multiple objectEffects

### DIFF
--- a/lib/psd/layer/info.coffee
+++ b/lib/psd/layer/info.coffee
@@ -28,6 +28,7 @@ LAYER_INFO = {
   name:                   require('../layer_info/unicode_name.coffee')
   nestedSectionDivider:   require('../layer_info/nested_section_divider.coffee')
   objectEffects:          require('../layer_info/object_effects.coffee')
+  multipleObjectEffects:  require('../layer_info/multiple_object_effects.coffee')
   sectionDivider:         require('../layer_info/section_divider.coffee')
   solidColor:             require('../layer_info/solid_color.coffee')
   typeTool:               require('../layer_info/typetool.coffee')
@@ -39,8 +40,8 @@ LAYER_INFO = {
 
 module.exports =
   parseLayerInfo: ->
-    # Layer info blocks are the last section in the layer, so we can continue until our
-    # file cursor reaches the end of the layer.
+  # Layer info blocks are the last section in the layer, so we can continue until our
+  # file cursor reaches the end of the layer.
     while @file.tell() < @layerEnd
       @file.seek 4, true # sig
 

--- a/lib/psd/layer_info/multiple_object_effects.coffee
+++ b/lib/psd/layer_info/multiple_object_effects.coffee
@@ -1,8 +1,8 @@
 LayerInfo = require '../layer_info.coffee'
 Descriptor = require '../descriptor.coffee'
 
-module.exports = class ObjectEffects extends LayerInfo
-  @shouldParse: (key) -> key is 'lfx2'
+module.exports = class MultipleObjectEffects extends LayerInfo
+  @shouldParse: (key) -> key is 'lmfx'
 
   parse: ->
     @file.seek 8, true

--- a/lib/psd/layer_info/object_effects.coffee
+++ b/lib/psd/layer_info/object_effects.coffee
@@ -2,9 +2,8 @@ LayerInfo = require '../layer_info.coffee'
 Descriptor = require '../descriptor.coffee'
 
 module.exports = class ObjectEffects extends LayerInfo
-  @shouldParse: (key) -> key is 'lfx2'
+  @shouldParse: (key) -> key is 'lfx2' or 'lmfx'
 
   parse: ->
-    console.log('build test')
     @file.seek 8, true
     @data = new Descriptor(@file).parse()

--- a/lib/psd/layer_info/object_effects.coffee
+++ b/lib/psd/layer_info/object_effects.coffee
@@ -2,7 +2,7 @@ LayerInfo = require '../layer_info.coffee'
 Descriptor = require '../descriptor.coffee'
 
 module.exports = class ObjectEffects extends LayerInfo
-  @shouldParse: (key) -> key is 'lfx2'
+  @shouldParse: (key) -> key is 'lfx2' or 'lmfx'
 
   parse: ->
     @file.seek 8, true

--- a/lib/psd/layer_info/object_effects.coffee
+++ b/lib/psd/layer_info/object_effects.coffee
@@ -2,8 +2,9 @@ LayerInfo = require '../layer_info.coffee'
 Descriptor = require '../descriptor.coffee'
 
 module.exports = class ObjectEffects extends LayerInfo
-  @shouldParse: (key) -> key is 'lfx2' or 'lmfx'
+  @shouldParse: (key) -> key is 'lfx2'
 
   parse: ->
+    console.log('build test')
     @file.seek 8, true
     @data = new Descriptor(@file).parse()

--- a/lib/psd/layer_info/object_effects.coffee
+++ b/lib/psd/layer_info/object_effects.coffee
@@ -2,7 +2,7 @@ LayerInfo = require '../layer_info.coffee'
 Descriptor = require '../descriptor.coffee'
 
 module.exports = class ObjectEffects extends LayerInfo
-  @shouldParse: (key) -> key is 'lfx2' or 'lmfx'
+  @shouldParse: (key) -> key is 'lfx2'
 
   parse: ->
     @file.seek 8, true


### PR DESCRIPTION
13dab09
objectEffects block id varies from `lfx2` to `lmfx` with multiple layer effect(e.g. multiple strokes), add `lmfx` to `object_effect.coffee` for support, otherwise objectEffect layer is skipped.

Layer info block keys:
![image](https://user-images.githubusercontent.com/22112899/60087622-520d8c00-9778-11e9-9333-1dc1a9e0b95d.png)  `lfx2` when single stroke. (line 2) 
![image](https://user-images.githubusercontent.com/22112899/60087715-85501b00-9778-11e9-802a-47900307fbd1.png) `lmfx` when multiple stroke.

![image](https://user-images.githubusercontent.com/22112899/60144204-83c83680-97fc-11e9-9992-f495d969cad7.png) single stroke info

![image](https://user-images.githubusercontent.com/22112899/60088777-330ff980-977a-11e9-81cd-9c5e74e1c4f7.png) multiple stroke info
