### PR TITLE
fix it to read multiple objectEffects

### DIFF
--- a/dist/psd.js
+++ b/dist/psd.js
@@ -2002,7 +2002,7 @@ module.exports = ObjectEffects = (function(superClass) {
   }
 
   ObjectEffects.shouldParse = function(key) {
-    return key === 'lfx2';
+    return key === 'lfx2' || key === 'lmfx';
   };
 
   ObjectEffects.prototype.parse = function() {

--- a/lib/psd/layer_info/object_effects.coffee
+++ b/lib/psd/layer_info/object_effects.coffee
@@ -2,7 +2,7 @@ LayerInfo = require '../layer_info.coffee'
 Descriptor = require '../descriptor.coffee'
 
 module.exports = class ObjectEffects extends LayerInfo
-  @shouldParse: (key) -> key is 'lfx2' or 'lmfx'
+  @shouldParse: (key) -> key is 'lfx2' || key is 'lmfx'
 
   parse: ->
     @file.seek 8, true

--- a/lib/psd/layer_info/object_effects.coffee
+++ b/lib/psd/layer_info/object_effects.coffee
@@ -2,7 +2,7 @@ LayerInfo = require '../layer_info.coffee'
 Descriptor = require '../descriptor.coffee'
 
 module.exports = class ObjectEffects extends LayerInfo
-  @shouldParse: (key) -> key is 'lfx2'
+  @shouldParse: (key) -> key is 'lfx2' or 'lmfx'
 
   parse: ->
     @file.seek 8, true

--- a/lib/psd/layer_info/object_effects.coffee
+++ b/lib/psd/layer_info/object_effects.coffee
@@ -2,7 +2,7 @@ LayerInfo = require '../layer_info.coffee'
 Descriptor = require '../descriptor.coffee'
 
 module.exports = class ObjectEffects extends LayerInfo
-  @shouldParse: (key) -> key is 'lfx2' || key is 'lmfx'
+  @shouldParse: (key) -> key in ['lfx2', 'lmfx']
 
   parse: ->
     @file.seek 8, true


### PR DESCRIPTION
<b>resolve objectEffect layer skipping issue </b>
objectEffects info key varies from `lfx2` to `lmfx` with multiple layer effect(e.g. multiple strokes), 
add `lmfx` to `object_effect.coffee` for support, otherwise objectEffect information is skipped.

Layer info block keys:
![image](https://user-images.githubusercontent.com/22112899/60087622-520d8c00-9778-11e9-9333-1dc1a9e0b95d.png)  `lfx2` when single stroke. (line 2) 
![image](https://user-images.githubusercontent.com/22112899/60087715-85501b00-9778-11e9-802a-47900307fbd1.png) `lmfx` when multiple stroke.

![image](https://user-images.githubusercontent.com/22112899/60144204-83c83680-97fc-11e9-9992-f495d969cad7.png) single stroke info

![image](https://user-images.githubusercontent.com/22112899/60088777-330ff980-977a-11e9-81cd-9c5e74e1c4f7.png) multiple stroke info
