### PR TITLE
Added file version exception

### DIFF
--- a/lib/psd/header.coffee
+++ b/lib/psd/header.coffee
@@ -59,6 +59,8 @@ module.exports = class Header extends Module
     if @sig != '8BPS'
       throw new Error('Invalid file signature detected. Got: '+@sig+'. Expected 8BPS.')
     @version = @file.readUShort()
+    if @version != 1
+      throw new Error('Invalid file version. Got: '+@version+'. Expected 1.')
 
     @file.seek 6, true
 


### PR DESCRIPTION
The documentation says:
"Version: always equal to 1. Do not try to read the file if the version does not match this value."
https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/#50577409_19840
