### PR TITLE
Update README to point to `psd.js` instead of `psd`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Runs in both NodeJS and the browser (using browserify). There are still some pie
 
 ## Installation
 
-PSD.js has no native dependencies. Simply add `psd` to your package.json or run `npm install psd`.
+PSD.js has no native dependencies. Simply add `psd.js` to your package.json or run `npm install psd.js`.
 
 ## Documentation
 


### PR DESCRIPTION
Hello! Thanks for writing such an excellent library! We've been updating one of our services that depends on this code, and ran into some installation snags in the process. Based on issue #195, it _seems_ that the npm package referenced in the README is out-of-date.

### Explanation
Pointing at `psd` downloads a version without a `dist` folder. When used in a project with `webpack`,
the package is quite difficult to build, throwing out a lot of issues with various `coffeescript` libraries. The built version of `psd` within the `psd.js` npm package
works perfectly out of the box

### Changes
This PR updates the references from `psd` to `psd.js`
