### PR TITLE
Update psd.js entry to point to dist/ instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "psd",
   "description": "A general purpose Photoshop file parser.",
   "version": "3.2.1",
-  "main": "./index.js",
+  "main": "dist/psd.js",
   "keywords": [
     "psd",
     "parser",


### PR DESCRIPTION
# Summary
- Fixes #233.
- We want to update the `main` entry in package.json to use the `dist` compiler version of `psd.js`

# Background
N/A

# Acceptance
- [ ] Make sure it still works.