### PR TITLE
Delete useless parseFloat

### DIFF
--- a/lib/psd/file.coffee
+++ b/lib/psd/file.coffee
@@ -85,4 +85,4 @@ module.exports = class File
     b3 = arr[2]
     b = b1 | b2 | b3
 
-    parseFloat(a, 10) + parseFloat(b / Math.pow(2, 24), 10)
+    a + (b / Math.pow(2, 24))


### PR DESCRIPTION
1. parseFloat has no second argument.
2. File data is Uint8Array. Both methods `@readByte` and `@read(3)` return numbers.